### PR TITLE
Add ability to use libraries with custom extensions.

### DIFF
--- a/lib/library.js
+++ b/lib/library.js
@@ -31,10 +31,13 @@ var EXT = Library.EXT = {
  * ForeignFunction.
  */
 
-function Library (libfile, funcs, lib) {
+function Library (libfile, funcs, lib, customExt) {
   debug('creating Library object for', libfile)
 
-  if (libfile && libfile.indexOf(EXT) === -1) {
+  if (libfile && customExt) {
+     debug('appending the custom library extension to the library name', customExt)
+     libfile += customExt
+  } else if (libfile && libfile.indexOf(EXT) === -1) {
     debug('appending library extension to library name', EXT)
     libfile += EXT
   }


### PR DESCRIPTION
Some libraries could have extensions different than listed in library.js.
For exaple winspool.drv in windows.

The current fix allows using bindings to libraries with custom extensions.
For example:
const winspoolLib = new ffi.Library('winspool', {
         'GetDefaultPrinterW': [ int, [ wchar_string, intPtr ] ]
      }, null, '.drv');